### PR TITLE
🐛 Fix/email timestamp

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-We actively support the following versions of `dj-logging` with security updates:
+We actively support the following versions of `django_logging` with security updates:
 
 | Version   | Supported          |
 | --------- | ------------------ |
@@ -12,7 +12,7 @@ We actively support the following versions of `dj-logging` with security updates
 
 ## Reporting a Vulnerability
 
-We take security issues seriously. If you find a vulnerability in `dj-logging`, please report it confidentially. Here are the steps to report security vulnerabilities:
+We take security issues seriously. If you find a vulnerability in `django_logging`, please report it confidentially. Here are the steps to report security vulnerabilities:
 
 1. **Email**: Please send an email to [aryan513966@gmail.com](mailto:aryan513966@gmail.com) with a detailed description of the vulnerability.
 2. **Details**: In your email, include the following details:
@@ -29,18 +29,18 @@ We will:
 ## Handling Vulnerabilities
 
 When a vulnerability is confirmed:
-- We will create a fix and apply it to all actively supported versions of `dj-logging`.
+- We will create a fix and apply it to all actively supported versions of `django_logging`.
 - A new release with the security fix will be published, and the vulnerability will be disclosed in the changelog or via a security advisory.
 - We may delay the disclosure of details about the vulnerability until a sufficient number of users have updated to the patched version.
 
 ## General Security Guidelines
 
-- Keep your `dj-logging` package up to date with the latest versions to ensure you benefit from the latest security fixes.
+- Keep your `django_logging` package up to date with the latest versions to ensure you benefit from the latest security fixes.
 - Follow our changelog for announcements regarding security fixes.
 - Ensure that your logging configuration is secure and does not expose sensitive information in log files.
 
 ## Responsible Disclosure
 
-We strongly encourage responsible disclosure and will work to fix issues in a timely manner. We appreciate any effort to help make `dj-logging` more secure for all users.
+We strongly encourage responsible disclosure and will work to fix issues in a timely manner. We appreciate any effort to help make `django_logging` more secure for all users.
 
-Thank you for helping us improve the security of `dj-logging`!
+Thank you for helping us improve the security of `django_logging`!

--- a/django_logging/handlers/email_handler.py
+++ b/django_logging/handlers/email_handler.py
@@ -4,7 +4,7 @@ from typing import Optional
 from django.conf import settings
 from django.http import HttpRequest
 from django.template import engines
-from django.utils.timezone import now
+from django.utils.timezone import localtime
 
 from django_logging.middleware import RequestLogMiddleware
 from django_logging.utils.get_conf import use_email_notifier_template
@@ -46,7 +46,7 @@ class EmailHandler(Handler):
         )
 
         # Get current time
-        current_time = now()
+        current_time = localtime()
 
         # Format date and time separately
         formatted_date = current_time.strftime("%d %B %Y").replace(

--- a/django_logging/handlers/email_handler.py
+++ b/django_logging/handlers/email_handler.py
@@ -12,7 +12,40 @@ from django_logging.utils.log_email_notifier.notifier import send_email_async
 
 
 class EmailHandler(Handler):
+    """A custom logging handler that sends log records via email.
+
+    This handler formats log records, optionally renders them using an
+    email template, and sends the resulting email to the administrator's
+    email address defined in the Django settings.
+
+    Methods:
+    -------
+        emit(record: LogRecord) -> None:
+            Processes a log record and sends it via email to the administrator.
+
+        render_template(log_entry: str, request: Optional[HttpRequest] = None, template_path: str = "email_notifier_template.html") -> str:
+            Renders the email body using the provided log entry and optional request details.
+            The rendered email includes the log message, the current date and time,
+            the user's IP address, and browser information.
+
+    """
+
     def emit(self, record: LogRecord) -> None:
+        """Processes a log record and sends it via email.
+
+        This method retrieves the request from the log record (if available), formats
+        the log message, optionally renders the email body using a template, and sends
+        the email asynchronously to the administrator.
+
+        Args:
+        ----
+            record (LogRecord): The log record to be processed and sent via email.
+
+        Raises:
+        ------
+            Exception: If any error occurs while sending the email or formatting the log record.
+
+        """
         try:
             request = getattr(record, "request", None)
             log_entry = self.format(record)
@@ -34,6 +67,25 @@ class EmailHandler(Handler):
         request: Optional[HttpRequest] = None,
         template_path: str = "email_notifier_template.html",
     ) -> str:
+        """Renders the email body using a Django template.
+
+        This method uses the provided log entry and request (if available)
+        to generate an HTML email body. The email includes details such as the
+        log message, current date and time, the IP address, and browser type
+        of the user making the request.
+
+        Args:
+        ----
+            log_entry (str): The formatted log message to be included in the email.
+            request (Optional[HttpRequest]): The HTTP request associated with the log entry, if available.
+            template_path (str): The path to the Django template to be used for rendering the email.
+                                 Defaults to "email_notifier_template.html".
+
+        Returns:
+        -------
+            str: The rendered email body as a string.
+
+        """
         django_engine = engines["django"]
         template = django_engine.get_template(template_path)
 

--- a/django_logging/tests/conftest.py
+++ b/django_logging/tests/conftest.py
@@ -18,6 +18,6 @@ from django_logging.tests.fixtures import (
     request_middleware,
     reset_settings,
 )
-from django_logging.tests.settings_configuration import configure_django_settings
+from django_logging.tests.setup import configure_django_settings
 
 configure_django_settings()

--- a/django_logging/tests/setup.py
+++ b/django_logging/tests/setup.py
@@ -47,5 +47,9 @@ def configure_django_settings():
             EMAIL_HOST_PASSWORD="the_password",
             DEFAULT_FROM_EMAIL="example@test.com",
             ADMIN_EMAIL="admin@test.com",
+            LANGUAGE_CODE="en-us",
+            TIME_ZONE="UTC",
+            USE_I18N=True,
+            USE_TZ=True,
         )
         django.setup()


### PR DESCRIPTION
- Replaced `timezone.now()` with `timezone.localtime()` in `EmailHandler` to ensure
the correct local time is used for emails, matching the configured
`TIME_ZONE` setting in Django.

- Added comprehensive docstrings to the `EmailHandler` class and its methods to improve code documentation.
These docstrings explain the functionality, arguments, and return values, enhancing code readability and maintainability.

Closes #88